### PR TITLE
Upgrade to clover 3.0.3 jar to avoid NPE in some cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,20 @@
         <dependency>
             <groupId>com.cenqua.clover</groupId>
             <artifactId>clover</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
+        </dependency>
+        <!--Build breaks without these:-->
+        <dependency>
+            <groupId>jfree</groupId>
+            <artifactId>jcommon</artifactId>
+            <version>1.0.16</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jfree</groupId>
+            <artifactId>jfreechart</artifactId>
+            <version>1.0.13</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We've already published clover 3.0.3 in our public repo: https://maven.atlassian.com/public/com/cenqua/clover/clover/3.0.3/

This should land in Maven Central soon. Once it does, please apply this small patch to the Jenkins Clover plugin. http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.cenqua.clover%22%20AND%20a%3A%22clover%22

Cheers,
Nick
