### PR TITLE
JENKINS-9830: Upgrade Clover dependency for Clover 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.cenqua.clover</groupId>
             <artifactId>clover</artifactId>
-            <version>3.0.3</version>
+            <version>3.1.0</version>
         </dependency>
         <!--Build breaks without these:-->
         <dependency>


### PR DESCRIPTION
Clover 3.1.0 is released. This pull upgrades the dependency.
