### PR TITLE
Percentage bars fixed

### DIFF
--- a/src/main/resources/hudson/plugins/clover/tags/coverage-bar.jelly
+++ b/src/main/resources/hudson/plugins/clover/tags/coverage-bar.jelly
@@ -8,7 +8,7 @@
         <!-- Just a dash of the Clover Secret Sauce ;) -->
         .barEmpty { FONT-SIZE: 2px; BACKGROUND: #c0c0c0; BORDER: #9c9c9c 1px solid; HEIGHT: 12px; WIDTH: 100%; }
         .barNegative { FONT-SIZE: 2px; BACKGROUND: #DF0000; BORDER: #9c9c9c 1px solid; TEXT-ALIGN: left; HEIGHT: 12px; WIDTH: 100%; }
-        .barPositive { FONT-SIZE: 2px; BACKGROUND: #00DF00; HEIGHT: 12}
+        .barPositive { FONT-SIZE: 2px; BACKGROUND: #00DF00; HEIGHT: 12px; }
     </style>
 
     <div style="width: 100px; font-size:0px;"></div>


### PR DESCRIPTION
The progress bars were showing as all red despite there being a non 0 percentage present.  Turns out it was just the height of the green bar that was being killed by Chrome/Firefox/Safari cause it didn't have the 'px' or ';'

before
https://skitch.com/captin411/gbaaa/jenkins

after
https://skitch.com/captin411/gb2y2/jenkins
