### PR TITLE
Use RunAction2 so that CloverBuildAction.owner may be transient.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.2</version>
+        <version>1.509.3</version>
     </parent>
     <artifactId>clover</artifactId>
     <packaging>hpi</packaging>

--- a/src/main/java/hudson/plugins/clover/CloverBuildAction.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildAction.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.HealthReport;
 import hudson.model.HealthReportingAction;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.plugins.clover.results.AbstractPackageAggregatedMetrics;
 import hudson.plugins.clover.results.ClassCoverage;
 import hudson.plugins.clover.results.FileCoverage;
@@ -19,6 +20,7 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.RunAction2;
 import org.jvnet.localizer.Localizable;
 
 
@@ -29,8 +31,8 @@ import org.jvnet.localizer.Localizable;
  * @author connollys
  * @since 03-Jul-2007 08:43:08
  */
-public class CloverBuildAction extends AbstractPackageAggregatedMetrics implements HealthReportingAction, StaplerProxy {
-    public final AbstractBuild owner;
+public class CloverBuildAction extends AbstractPackageAggregatedMetrics implements HealthReportingAction, StaplerProxy, RunAction2 {
+    public transient AbstractBuild owner;
     private String buildBaseDir;
     private CoverageTarget healthyTarget;
     private CoverageTarget unhealthyTarget;
@@ -118,9 +120,7 @@ public class CloverBuildAction extends AbstractPackageAggregatedMetrics implemen
         }
     }
 
-    CloverBuildAction(AbstractBuild owner, String workspacePath, ProjectCoverage r, CoverageTarget healthyTarget,
-                      CoverageTarget unhealthyTarget) {
-        this.owner = owner;
+    CloverBuildAction(String workspacePath, ProjectCoverage r, CoverageTarget healthyTarget, CoverageTarget unhealthyTarget) {
         this.report = new WeakReference<ProjectCoverage>(r);
         this.buildBaseDir = workspacePath;
         if (this.buildBaseDir == null) {
@@ -130,9 +130,21 @@ public class CloverBuildAction extends AbstractPackageAggregatedMetrics implemen
         }
         this.healthyTarget = healthyTarget;
         this.unhealthyTarget = unhealthyTarget;
-        r.setOwner(owner);
     }
 
+    @Override public void onAttached(Run<?,?> r) {
+        owner = (AbstractBuild) r;
+        if (report != null) {
+            ProjectCoverage c = report.get();
+            if (c != null) {
+                c.setOwner(owner);
+            }
+        }
+    }
+
+    @Override public void onLoad(Run<?,?> r) {
+        owner = (AbstractBuild) r;
+    }
     
     /** Obtains the detailed {@link CoverageReport} instance. */
     public synchronized ProjectCoverage getResult() {
@@ -260,8 +272,7 @@ public class CloverBuildAction extends AbstractPackageAggregatedMetrics implemen
 
     private static final Logger logger = Logger.getLogger(CloverBuildAction.class.getName());
 
-    public static CloverBuildAction load(AbstractBuild<?, ?> build, String workspacePath, ProjectCoverage result,
-                                         CoverageTarget healthyTarget, CoverageTarget unhealthyTarget) {
-        return new CloverBuildAction(build, workspacePath, result, healthyTarget, unhealthyTarget);
+    public static CloverBuildAction load(String workspacePath, ProjectCoverage result, CoverageTarget healthyTarget, CoverageTarget unhealthyTarget) {
+        return new CloverBuildAction(workspacePath, result, healthyTarget, unhealthyTarget);
     }
 }

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -205,9 +205,7 @@ public class CloverPublisher extends Recorder {
                 e.printStackTrace(listener.fatalError("Unable to copy coverage from " + coverageReport + " to " + buildTarget));
                 build.setResult(Result.FAILURE);
             }
-            final CloverBuildAction action = CloverBuildAction.load(build, workspacePath, result, healthyTarget, unhealthyTarget);
-
-            build.getActions().add(action);
+            build.addAction(CloverBuildAction.load(workspacePath, result, healthyTarget, unhealthyTarget));
             Set<CoverageMetric> failingMetrics = failingTarget.getFailingMetrics(result);
             if (!failingMetrics.isEmpty()) {
                 listener.getLogger().println("Code coverage enforcement failed for the following metrics:");


### PR DESCRIPTION
Otherwise the serial form of the action will encode the enclosing build. Normally this is harmless if ugly (XStream uses a backlink). But under lazy loading with garbage collection and recreation of builds, sometimes this results in the action saving a complete copy of the build (just backlinking to itself, the action). Then this can eventually cause a `Run` to be loaded which has no parent `Job`. Mayhem results:

```
java.lang.NullPointerException
    at hudson.model.Run.getRootDir(Run.java:976)
    at hudson.plugins.clover.CloverPublisher.getCloverXmlReport(CloverPublisher.java:127)
    at hudson.plugins.clover.CloverBuildAction.getResult(CloverBuildAction.java:144)
    at hudson.plugins.clover.CloverBuildAction.getBuildHealth(CloverBuildAction.java:45)
```
