### PR TITLE
NONE: Bumped Clover version to use the newest major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <artifactId>clover</artifactId>
     <packaging>hpi</packaging>
-    <version>4.4.1-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <name>Jenkins Clover plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Clover+Plugin</url>
     <developers>
@@ -24,7 +24,7 @@
         <connection>scm:git:git://github.com/jenkinsci/clover-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/clover-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/clover-plugin</url>
-        <tag>clover-4.4.0</tag>
+        <tag>clover-4.5.0</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.atlassian.clover</groupId>
             <artifactId>clover</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.1</version>
         </dependency>
         <!--Build breaks without these:-->
         <dependency>


### PR DESCRIPTION
Clover 4.1.1 was released today. I bumped the version to let Jenkins-Clover use it. 