### PR TITLE
Truncate coverage percentages instead of rounding.

### DIFF
--- a/src/main/java/hudson/plugins/clover/Ratio.java
+++ b/src/main/java/hudson/plugins/clover/Ratio.java
@@ -79,7 +79,8 @@ final public class Ratio implements Serializable, CoverageBarProvider {
      * @return int percentage
      */
     public int getPercentage() {
-        return Math.round(getPercentageFloat());
+        /* intentional truncation to simulate floor() */
+        return (int)getPercentageFloat();
     }
 
     /**

--- a/src/test/java/hudson/plugins/clover/RatioTest.java
+++ b/src/test/java/hudson/plugins/clover/RatioTest.java
@@ -54,4 +54,26 @@ public class RatioTest extends TestCase {
         assertEquals("10/5 => 100", 100.0f, Ratio.create(10,5).getPercentageFloat(), 0.005f);
     }
 
+    /**
+     * Tests that {@link Ratio#getPercentage()} correctly handles values near
+     * whole integers.  In particular that 99.99% becomes 99% and not 100%
+     *
+     */
+    public void testGetPercentage() {
+        // truncate to zero
+        assertEquals("0/1000    =>   0",   0, Ratio.create(   0,1000).getPercentage());
+        assertEquals("9/1000    =>   0",   0, Ratio.create(   9,1000).getPercentage());
+
+        // truncate to 90
+        assertEquals("900/1000  =>  90",  90, Ratio.create( 900,1000).getPercentage());
+        assertEquals("909/1000  =>  90",  90, Ratio.create( 909,1000).getPercentage());
+
+        // truncate to 99
+        assertEquals("990/1000  =>  99",  99, Ratio.create( 990,1000).getPercentage());
+        assertEquals("999/1000  =>  99",  99, Ratio.create( 999,1000).getPercentage());
+
+        // still show 100
+        assertEquals("1000/1000 => 100", 100, Ratio.create(1000,1000).getPercentage());
+    }
+
 }


### PR DESCRIPTION
Previous functionality rounded coverage percentages so values such as
2999/3000 would turn into 100%.  This now rounds down to the next whole
integer so that 100% only happens when both values are the same.

Did a quick scrape but didn't see if this had been discussed and is currently as designed.

At my work we happen to need to meet regulatory standards that say 100% coverage is not 99.9% so we aren't able to take advantage of the plugins current health statistics. 