### PR TITLE
Update display of percentages to match getPercentage()

### DIFF
--- a/src/main/java/hudson/plugins/clover/Ratio.java
+++ b/src/main/java/hudson/plugins/clover/Ratio.java
@@ -1,6 +1,7 @@
 package hudson.plugins.clover;
 
 import java.io.Serializable;
+import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -15,6 +16,7 @@ final public class Ratio implements Serializable, CoverageBarProvider {
     public static final NumberFormat PC_WIDTH_FORMAT = NumberFormat.getInstance(Locale.US);
     static {
         PC_WIDTH_FORMAT.setMaximumFractionDigits(1);
+        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.DOWN);
     }
 
     private Ratio(float numerator, float denominator) {
@@ -62,7 +64,16 @@ final public class Ratio implements Serializable, CoverageBarProvider {
 
     public String getPcUncovered() {
         float pcUncovered = 100.0f - getPercentageFloat();
-        return pcFormat(pcUncovered);
+
+        /* Since this is the negative of getPcCovered() we need to invert the
+         * rounding mode to ensure it most closely complements getPcCovered() */
+        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.UP);
+        String uncovered = pcFormat(pcUncovered);
+
+        /* Restore the rounding mode for other calls */
+        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.DOWN);
+        return uncovered;
+
     }
 
     public String getPcCovered() {

--- a/src/main/java/hudson/plugins/clover/Ratio.java
+++ b/src/main/java/hudson/plugins/clover/Ratio.java
@@ -13,10 +13,14 @@ final public class Ratio implements Serializable, CoverageBarProvider {
     public final float numerator;
     public final float denominator;
 
-    public static final NumberFormat PC_WIDTH_FORMAT = NumberFormat.getInstance(Locale.US);
+    public static final NumberFormat PC_ROUND_DOWN_FORMAT = NumberFormat.getInstance(Locale.US);
+    public static final NumberFormat PC_ROUND_UP_FORMAT = NumberFormat.getInstance(Locale.US);
     static {
-        PC_WIDTH_FORMAT.setMaximumFractionDigits(1);
-        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.DOWN);
+        PC_ROUND_DOWN_FORMAT.setMaximumFractionDigits(1);
+        PC_ROUND_DOWN_FORMAT.setRoundingMode(RoundingMode.DOWN);
+
+        PC_ROUND_UP_FORMAT.setMaximumFractionDigits(1);
+        PC_ROUND_UP_FORMAT.setRoundingMode(RoundingMode.UP);
     }
 
     private Ratio(float numerator, float denominator) {
@@ -45,16 +49,16 @@ final public class Ratio implements Serializable, CoverageBarProvider {
      * @return String percentage
      */
     public String getPercentage1d() {
-        return PC_WIDTH_FORMAT.format(getPercentageFloat());
+        return PC_ROUND_DOWN_FORMAT.format(getPercentageFloat());
     }
 
     public String getPercentageStr() {
-        return denominator > 0 ? PC_WIDTH_FORMAT.format(getPercentageFloat()) + "%" : "-";
+        return denominator > 0 ? PC_ROUND_DOWN_FORMAT.format(getPercentageFloat()) + "%" : "-";
     }
 
 
     private String pcFormat(float pc) {
-        return Ratio.PC_WIDTH_FORMAT.format(pc) + "%";
+        return PC_ROUND_DOWN_FORMAT.format(pc) + "%";
     }
 
     public String getPcWidth() {
@@ -65,14 +69,7 @@ final public class Ratio implements Serializable, CoverageBarProvider {
     public String getPcUncovered() {
         float pcUncovered = 100.0f - getPercentageFloat();
 
-        /* Since this is the negative of getPcCovered() we need to invert the
-         * rounding mode to ensure it most closely complements getPcCovered() */
-        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.UP);
-        String uncovered = pcFormat(pcUncovered);
-
-        /* Restore the rounding mode for other calls */
-        PC_WIDTH_FORMAT.setRoundingMode(RoundingMode.DOWN);
-        return uncovered;
+        return PC_ROUND_UP_FORMAT.format(pcUncovered) + "%";
 
     }
 

--- a/src/test/java/hudson/plugins/clover/RatioTest.java
+++ b/src/test/java/hudson/plugins/clover/RatioTest.java
@@ -76,4 +76,48 @@ public class RatioTest extends TestCase {
         assertEquals("1000/1000 => 100", 100, Ratio.create(1000,1000).getPercentage());
     }
 
+    /**
+     * Tests that {@link Ratio#getPcCovered()} correctly handles values near
+     * whole integers.  This is to make sure that it will match that of
+     * getPercentage()
+     */
+    public void testGetPcCovered() {
+        // Make sure zero is zero
+        assertEquals("0/10000     =>    0",    "0%", Ratio.create(    0, 10000).getPcCovered());
+        assertEquals("9/10000     =>    0",    "0%", Ratio.create(    9, 10000).getPcCovered());
+
+        assertEquals("99/10000    =>  0.9",  "0.9%", Ratio.create(   99, 10000).getPcCovered());
+
+        assertEquals("9009/10000  =>   90",   "90%", Ratio.create( 9009, 10000).getPcCovered());
+        assertEquals("9099/10000  => 90.9", "90.9%", Ratio.create( 9099, 10000).getPcCovered());
+
+        assertEquals("9909/10000  =>   99",   "99%", Ratio.create( 9909, 10000).getPcCovered());
+        assertEquals("9999/10000  => 99.9", "99.9%", Ratio.create( 9999, 10000).getPcCovered());
+
+        // still show 100
+        assertEquals("10000/10000 =>  100",  "100%", Ratio.create(10000, 10000).getPcCovered());
+    }
+
+    /**
+     * Tests that {@link Ratio#getPcUncovered()} correctly handles values near
+     * whole integers.  
+     * This needs to correctly contrast with getPcCovered()
+     */
+    public void testGetPcUncovered() {
+        // Nothing should be 100%
+        assertEquals("0/10000     =>  100",  "100%", Ratio.create(    0, 10000).getPcUncovered());
+        assertEquals("9/10000     =>  100",  "100%", Ratio.create(    9, 10000).getPcUncovered());
+
+        assertEquals("9/10000     => 99.1", "99.1%", Ratio.create(   99, 10000).getPcUncovered());
+
+        assertEquals("9009/10000  =>   10",   "10%", Ratio.create( 9009, 10000).getPcUncovered());
+        assertEquals("9099/10000  =>  9.1",  "9.1%", Ratio.create( 9099, 10000).getPcUncovered());
+
+        assertEquals("9909/10000  =>    1",    "1%", Ratio.create( 9909, 10000).getPcUncovered());
+        assertEquals("9999/10000  =>  0.1",  "0.1%", Ratio.create( 9999, 10000).getPcUncovered());
+
+        // still show 0
+        assertEquals("10000/10000 =>    0",    "0%", Ratio.create(10000, 10000).getPcUncovered());
+    }
+
 }

--- a/src/test/java/hudson/plugins/clover/RatioTest.java
+++ b/src/test/java/hudson/plugins/clover/RatioTest.java
@@ -104,20 +104,29 @@ public class RatioTest extends TestCase {
      * This needs to correctly contrast with getPcCovered()
      */
     public void testGetPcUncovered() {
-        // Nothing should be 100%
-        assertEquals("0/10000     =>  100",  "100%", Ratio.create(    0, 10000).getPcUncovered());
-        assertEquals("9/10000     =>  100",  "100%", Ratio.create(    9, 10000).getPcUncovered());
+        // No coverage should be 100% uncovered
+        assertEquals("0/10000     = 0% covered     = 100% uncovered   = 100% rounded up", "100%",
+                     Ratio.create(    0, 10000).getPcUncovered());
 
-        assertEquals("9/10000     => 99.1", "99.1%", Ratio.create(   99, 10000).getPcUncovered());
+        assertEquals("9/10000     = 0.09% covered  = 99.91% uncovered = 100% rounded up", "100%",
+                     Ratio.create(    9, 10000).getPcUncovered());
 
-        assertEquals("9009/10000  =>   10",   "10%", Ratio.create( 9009, 10000).getPcUncovered());
-        assertEquals("9099/10000  =>  9.1",  "9.1%", Ratio.create( 9099, 10000).getPcUncovered());
+        assertEquals("99/10000    = 0.99% covered  = 99.01% uncovered = 99.1% rounded up", "99.1%",
+                     Ratio.create(   99, 10000).getPcUncovered());
 
-        assertEquals("9909/10000  =>    1",    "1%", Ratio.create( 9909, 10000).getPcUncovered());
-        assertEquals("9999/10000  =>  0.1",  "0.1%", Ratio.create( 9999, 10000).getPcUncovered());
+        assertEquals("9009/10000  = 90.09% covered = 9.91% uncovered  = 10% rounded up", "10%",
+                     Ratio.create( 9009, 10000).getPcUncovered());
+        assertEquals("9099/10000  = 90.99% covered = 9.01% uncovered  = 9.1% rounded up", "9.1%",
+                     Ratio.create( 9099, 10000).getPcUncovered());
 
-        // still show 0
-        assertEquals("10000/10000 =>    0",    "0%", Ratio.create(10000, 10000).getPcUncovered());
+        assertEquals("9909/10000  = 99.09% covered = 0.91% uncovered  = 1% rounded up", "1%",
+                     Ratio.create( 9909, 10000).getPcUncovered());
+        assertEquals("9999/10000  = 99.99% covered = 0.01% uncovered  = 0.1% rounded up", "0.1%",
+                     Ratio.create( 9999, 10000).getPcUncovered());
+
+        // still show 0 when 100% covered
+        assertEquals("10000/10000 = 100% covered   = 0% uncovered     = 0% rounded up", "0%", 
+                     Ratio.create(10000, 10000).getPcUncovered());
     }
 
 }


### PR DESCRIPTION
This prevents large values from showing up as 100%.
For example 9999/10000 would show up as 100%, but now it will display as
99.9%

Sorry it looks like I missed this when i submitted #18 
This synchronizes the display of percentages with the comparison of percentage values from getPercentage().

I'm not sure if there is a better way to handle the getPcUncovered() then what i did.
You may also might want to consider if i missed anything else.

Thanks!