### PR TITLE
[JENKINS-57229] Bogus serialization of FilePath in CloverHtmlBuildAction

### DIFF
--- a/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
+++ b/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
@@ -1,36 +1,34 @@
 package hudson.plugins.clover;
 
 
-import hudson.model.DirectoryBrowserSupport;
-import hudson.model.Action;
 import hudson.FilePath;
-import java.io.File;
+import hudson.model.DirectoryBrowserSupport;
+import hudson.model.Run;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import jenkins.util.VirtualFile;
+import jenkins.model.RunAction2;
 
 
 /**
  */
-public class CloverHtmlBuildAction implements Action {
+public class CloverHtmlBuildAction implements RunAction2 {
 
-    @Deprecated
-    transient FilePath buildReportPath; // location of the clover html for each build
+    private transient Run<?, ?> build;
 
-    private String buildReportLocation;
-
-    public CloverHtmlBuildAction(FilePath buildReportPath) {
-        this.buildReportLocation = buildReportPath.getRemote();
+    public CloverHtmlBuildAction() {
     }
 
-    private Object readResolve() {
-        if (buildReportPath != null) {
-            buildReportLocation = buildReportPath.getRemote();
-        }
-        return this;
+    @Override
+    public void onAttached(Run<?, ?> r) {
+        build = r;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> r) {
+        build = r;
     }
 
     public String getDisplayName() {
@@ -39,7 +37,7 @@ public class CloverHtmlBuildAction implements Action {
 
     public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException,
             InterruptedException {
-        return new DirectoryBrowserSupport(this, VirtualFile.forFile(new File(buildReportLocation)), "Clover Html Report", CloverProjectAction.ICON, false);
+        return new DirectoryBrowserSupport(this, new FilePath(build.getRootDir()), "Clover Html Report", CloverProjectAction.ICON, false);
     }
 
     public String getIconFileName() {

--- a/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
+++ b/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
@@ -4,21 +4,33 @@ package hudson.plugins.clover;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.model.Action;
 import hudson.FilePath;
+import java.io.File;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import jenkins.util.VirtualFile;
 
 
 /**
  */
 public class CloverHtmlBuildAction implements Action {
 
-    final FilePath buildReportPath; // location of the clover html for each build
+    @Deprecated
+    transient FilePath buildReportPath; // location of the clover html for each build
+
+    private String buildReportLocation;
 
     public CloverHtmlBuildAction(FilePath buildReportPath) {
-        this.buildReportPath = buildReportPath;
+        this.buildReportLocation = buildReportPath.getRemote();
+    }
+
+    private Object readResolve() {
+        if (buildReportPath != null) {
+            buildReportLocation = buildReportPath.getRemote();
+        }
+        return this;
     }
 
     public String getDisplayName() {
@@ -27,7 +39,7 @@ public class CloverHtmlBuildAction implements Action {
 
     public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException,
             InterruptedException {
-        return new DirectoryBrowserSupport(this, buildReportPath, "Clover Html Report", CloverProjectAction.ICON, false);
+        return new DirectoryBrowserSupport(this, VirtualFile.forFile(new File(buildReportLocation)), "Clover Html Report", CloverProjectAction.ICON, false);
     }
 
     public String getIconFileName() {

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -6,7 +6,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractProject;
-import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -177,7 +176,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
 
             if (htmlExists) {
                 // only add the HTML run action, if the HTML report is available
-                run.addAction(new CloverHtmlBuildAction(buildTarget));
+                run.addAction(new CloverHtmlBuildAction());
             }
             processCloverXml(run, workspace, listener, coverageReportDir, buildTarget);
 


### PR DESCRIPTION
[JENKINS-57229](https://issues.jenkins-ci.org/browse/JENKINS-57229)

https://github.com/jenkinsci/jenkins/pull/3980 highlighted that this plugin was saving a `FilePath` via XStream, which is not supported. In fact the `FilePath` always had a null `Channel`, since it was nothing more than a representation of a `File` on the Jenkins master.

Untested, YMMV.