### PR TITLE
Use parent pom 4.32, require Jenkins 2.289.1 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,6 @@
         </dependency>
     </dependencies>
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.642.3</version>
+        <version>4.32</version>
     </parent>
     <artifactId>clover</artifactId>
     <packaging>hpi</packaging>
@@ -30,9 +30,8 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- from org.jenkins-ci.plugins:plugin 3.x -->
-        <!--<java.level>8</java.level>-->
-        <!--<java.level.test>8</java.level.test>-->
+        <java.level>8</java.level>
+        <jenkins.version>2.289.1</jenkins.version>
     </properties>
     <dependencies>
         <dependency>
@@ -61,7 +60,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
-            <version>2.0</version>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.46</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+            <version>1.15</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -70,18 +87,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -337,6 +337,10 @@ public class CloverBuildWrapper extends BuildWrapper {
             FilePath path = new FilePath(new FilePath(starter.pwd(), ".clover"), "clover.jar");
             try {
                 String cloverJarLocation = ClassPathUtil.getCloverJarPath();
+                if (cloverJarLocation == null) {
+                    listener.getLogger().print("Could not get clover jar path at: " + path + ".  Please supply '-lib /path/to/clover.jar'.");
+                    return;
+                }
                 path.copyFrom(new FilePath(new File(cloverJarLocation)));
                 userArgs.add("-lib");
                 userArgs.add("\"" + path.getRemote() + "\"");

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -334,7 +334,12 @@ public class CloverBuildWrapper extends BuildWrapper {
         }
 
         private void addLibCloverFromBundledJar(List<String> userArgs, @NonNull ProcStarter starter, TaskListener listener) throws IOException {
-            FilePath path = new FilePath(new FilePath(starter.pwd(), ".clover"), "clover.jar");
+            FilePath starterPwd = starter.pwd();
+            if (starterPwd == null) {
+                listener.getLogger().print("Could not get clover jar path from " + starter);
+                return;
+            }
+            FilePath path = new FilePath(new FilePath(starterPwd, ".clover"), "clover.jar");
             try {
                 String cloverJarLocation = ClassPathUtil.getCloverJarPath();
                 if (cloverJarLocation == null) {

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
@@ -332,7 +333,7 @@ public class CloverBuildWrapper extends BuildWrapper {
             userArgs.add("\"" + clover.getHome() + "\"");
         }
 
-        private void addLibCloverFromBundledJar(List<String> userArgs, ProcStarter starter, TaskListener listener) throws IOException {
+        private void addLibCloverFromBundledJar(List<String> userArgs, @NonNull ProcStarter starter, TaskListener listener) throws IOException {
             FilePath path = new FilePath(new FilePath(starter.pwd(), ".clover"), "clover.jar");
             try {
                 String cloverJarLocation = ClassPathUtil.getCloverJarPath();

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -105,8 +105,6 @@ public class CloverBuildWrapper extends BuildWrapper {
 
     @Override
     public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
-
-        final DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
 
         final CIOptions.Builder options = new CIOptions.Builder()
                 .json(this.json)

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -255,7 +255,10 @@ public class CloverBuildWrapper extends BuildWrapper {
 
                 // masks.length must equal cmds.length
                 boolean[] masks = new boolean[starter.cmds().size()];
-                System.arraycopy(starter.masks(), 0, masks, 0, starter.masks().length);
+                boolean[] starterMasks = starter.masks();
+                if (starterMasks != null) {
+                    System.arraycopy(starterMasks, 0, masks, 0, starterMasks.length);
+                }
                 starter.masks(masks);
             }
         }

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -273,6 +273,10 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
             return false;
         }
         final FilePath htmlDirPath = htmlIndexHtmlPath.getParent();
+        if (htmlDirPath == null) {
+            listener.getLogger().println("Parent directory of " + htmlIndexHtmlPath.getRemote() + " is null, not publishing Clover HTML report.");
+            return false;
+        }
         listener.getLogger().println("Publishing Clover HTML report...");
         htmlDirPath.copyRecursiveTo("**/*", buildTarget);
         return true;

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -157,7 +157,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
             }
 
             // if the run has failed, then there's not much point in reporting an error
-            Result result = run.getResult();
+            final Result result = run.getResult();
             final boolean buildFailure = result != null && result.isWorseOrEqualTo(Result.FAILURE);
             final boolean missingReport = !coverageReportDir.exists();
 

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -22,7 +22,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -136,8 +136,8 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
-                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher,
+                        @NonNull TaskListener listener) throws InterruptedException, IOException {
         performImpl(run, workspace, listener);
     }
 
@@ -216,7 +216,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
         }
     }
 
-    @Nonnull
+    @NonNull
     private String getWorkspacePath(TaskListener listener, FilePath workspace) throws InterruptedException {
         try {
             return workspace.act(new GetPathFileCallable());
@@ -226,12 +226,12 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
         }
     }
 
-    @Nonnull
-    private String withTrailingSeparator(@Nonnull String path) {
+    @NonNull
+    private String withTrailingSeparator(@NonNull String path) {
         return path.endsWith(File.separator) ? path : (path + File.separator);
     }
 
-    @Nonnull
+    @NonNull
     private Set<CoverageMetric> getFailingMetrics(ProjectCoverage result) {
         return failingTarget != null
                 ? failingTarget.getFailingMetrics(result)
@@ -340,7 +340,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
         /**
          * This human readable name is used in the configuration screen.
          */
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.CloverPublisher_DisplayName();
@@ -357,7 +357,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
          * Creates a new instance of {@link CloverPublisher} from a submitted form.
          */
         @Override
-        public CloverPublisher newInstance(StaplerRequest req, @Nonnull JSONObject formData) {
+        public CloverPublisher newInstance(@NonNull StaplerRequest req, @NonNull JSONObject formData) {
             final CloverPublisher instance = new CloverPublisher(
                     req.getParameter("clover.cloverReportDir"),
                     req.getParameter("clover.cloverReportFileName"),

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -157,7 +157,8 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
             }
 
             // if the run has failed, then there's not much point in reporting an error
-            final boolean buildFailure = run.getResult() != null && run.getResult().isWorseOrEqualTo(Result.FAILURE);
+            Result result = run.getResult();
+            final boolean buildFailure = result != null && result.isWorseOrEqualTo(Result.FAILURE);
             final boolean missingReport = !coverageReportDir.exists();
 
             if (buildFailure || missingReport) {


### PR DESCRIPTION
## Use parent pom 4.32, require Jenkins 2.289.1 or newer

Use the most recent parent pom.  It provides spotbugs analysis and requires Java 8 syntax.

https://stats.jenkins.io/pluginversions/clover.html shows that 90% of the 1321 installations of clover plugin 4.12.1 are on Jenkins 2.289.1 or newer.  Users that are updating the plugin version are also updating their Jenkins version.

Added some code changes to resolve spotbugs warnings and added one suppression to silence a spotbugs warning.