### PR TITLE
Use https:// instead of git:// for SCM connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/clover-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/clover-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/clover-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/clover-plugin</url>
         <tag>clover-4.7.0</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </developers>
     <scm>
         <connection>scm:git:https://github.com/jenkinsci/clover-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/clover-plugin.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/clover-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/clover-plugin</url>
         <tag>clover-4.7.0</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>hpi</packaging>
     <version>4.12.2-SNAPSHOT</version>
     <name>Jenkins Clover plugin</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Clover+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Clover+Plugin</url>
     <developers>
         <developer>
             <id>marek-parfianowicz</id>
@@ -25,7 +25,7 @@
     <scm>
         <connection>scm:git:https://github.com/jenkinsci/clover-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/clover-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/clover-plugin</url>
+        <url>https://github.com/jenkinsci/clover-plugin</url>
         <tag>clover-4.7.0</tag>
     </scm>
     <properties>


### PR DESCRIPTION
## Use https:// instead of git:// for SCM connection

https://github.blog/2021-09-01-improving-git-protocol-security-github/#whats-changing declares that the unencrypted git:// protocol is being deprecated by GitHub.
