### PR TITLE
Run tests in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1C</forkCount>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>


### PR DESCRIPTION
## Run tests in parallel

The parent pom switched to not run tests in parallel.  This brings back the parallel execution on machines with multiple cores.  Use multiple cores more effectively by forking processes based on number of cores, then reuse the forks to run more tests.
