### PR TITLE
OC-117: use the latest openclover 4.5.0, bump plugin version too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <tag>${scmTag}</tag>
     </scm>
     <properties>
-        <revision>4.13.1</revision>
+        <revision>4.14.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/clover-plugin</gitHubRepo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.openclover</groupId>
             <artifactId>clover</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade to OpenClover 4.5.0

### Testing done

CI automated tests
