### PR TITLE
OC-117: prepare for automatic releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,7 @@
+_extends: .github
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: clover-$NEXT_PATCH_VERSION
+
+replacers:
+  - search: '/\[*OC-(\d+)\]*\s*-*\s*/g'
+    replace: '[OC-$1](https://github.com/openclover/clover/issues/$1) - '

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <artifactId>clover</artifactId>
     <packaging>hpi</packaging>
-    <version>${revision}${changelist}</version>
+    <version>${revision}.${changelist}</version>
     <name>Jenkins Clover plugin</name>
     <url>https://github.com/jenkinsci/clover-plugin</url>
     <developers>
@@ -31,7 +31,7 @@
     <properties>
         <gpg.skip>true</gpg.skip> <!-- sign only when releasing -->
         <revision>4.14.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/clover-plugin</gitHubRepo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.level>8</java.level>


### PR DESCRIPTION
OC-117: using semver MAJOR.MINOR.PATCH for versioning (instead of MAJOR.MINOR), added chagelist.format, manual management of first three digits of a version number, adding links to openclover github issues for any OC-xxx key

### Testing done

CI status
