### PR TITLE
OC-213: Upgrade to OpenClover 4.5.2, which brings support for entire Java 17 language grammar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     </scm>
     <properties>
         <gpg.skip>true</gpg.skip> <!-- sign only when releasing -->
-        <revision>4.14.1</revision>
+        <revision>4.14.2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/clover-plugin</gitHubRepo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.version>2.387.3</jenkins.version>
-        <clover.version>4.5.1</clover.version>
+        <clover.version>4.5.2</clover.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Upgrade to OpenClover 4.5.2. This release brings support for Java 14 switch expressions, Java 14 instanceof pattern matching as well as Java 17 sealed types. This means that entire Java 17 language grammar is fully supported now. Reference: https://openclover.org/doc/openclover-4.5.2-release-notes.html

### Testing done

Automated tests.

