### PR TITLE
Migrate from Jakarta EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.87</version>
+        <version>5.9</version>
+        <relativePath />
     </parent>
     <artifactId>clover</artifactId>
     <packaging>hpi</packaging>
     <version>${revision}.${changelist}</version>
     <name>Jenkins Clover plugin</name>
-    <url>https://github.com/jenkinsci/clover-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <developers>
         <developer>
             <id>marek-parfianowicz</id>
@@ -24,7 +26,7 @@
     </developers>
     <scm>
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
@@ -32,10 +34,9 @@
         <gpg.skip>true</gpg.skip> <!-- sign only when releasing -->
         <revision>4.14.2</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/clover-plugin</gitHubRepo>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.440</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <clover.version>4.5.2</clover.version>
     </properties>
@@ -45,7 +46,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3307.v2769886db_63b_</version>
+                <version>3944.v1a_e4f8b_452db_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,6 +63,17 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-digester3</artifactId>
             <version>3.2</version>
+            <exclusions>
+                <!-- Provided by asm-api plugin -->
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>asm-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
@@ -69,69 +81,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.1.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
     <profiles>
         <profile>
-            <id>release-profile</id>
+            <id>jenkins-release</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.5</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.10.0</version>
-                        <configuration>
-                            <!-- do not spam the console -->
-                            <quiet>true</quiet>
-                            <!-- omit javadoc generation from target/generated-sources -->
-                            <sourcepath>${basedir}/src/main/java</sourcepath>
-                            <tags>
-                                <!-- for @stapler-constructor annotation -->
-                                <tag>
-                                    <name>stapler</name>
-                                    <placement>X</placement>
-                                </tag>
-                            </tags>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
+++ b/src/main/java/hudson/plugins/clover/CloverBuildWrapper.java
@@ -26,7 +26,7 @@ import hudson.util.DescribableList;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -153,7 +153,7 @@ public class CloverBuildWrapper extends BuildWrapper {
 
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) {
+        public boolean configure(StaplerRequest2 req, JSONObject json) {
             req.bindParameters(this, "clover.");
             save();
             return true;

--- a/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
+++ b/src/main/java/hudson/plugins/clover/CloverHtmlBuildAction.java
@@ -5,8 +5,8 @@ import hudson.FilePath;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 
 public class CloverHtmlBuildAction implements RunAction2 {
@@ -30,7 +30,7 @@ public class CloverHtmlBuildAction implements RunAction2 {
         return Messages.CloverHtmlBuildAction_DisplayName();
     }
 
-    public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) {
+    public DirectoryBrowserSupport doDynamic(StaplerRequest2 req, StaplerResponse2 rsp) {
         return new DirectoryBrowserSupport(this, new FilePath(build.getRootDir()), "Clover Html Report", CloverProjectAction.ICON, false);
     }
 

--- a/src/main/java/hudson/plugins/clover/CloverInstallation.java
+++ b/src/main/java/hudson/plugins/clover/CloverInstallation.java
@@ -9,7 +9,7 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -61,7 +61,7 @@ public class CloverInstallation extends ToolInstallation implements NodeSpecific
         }
 
         @Override
-        public CloverInstallation newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public CloverInstallation newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return (CloverInstallation) super.newInstance(req, formData.getJSONObject("cloverInstallation"));
         }
     }

--- a/src/main/java/hudson/plugins/clover/CloverProjectAction.java
+++ b/src/main/java/hudson/plugins/clover/CloverProjectAction.java
@@ -8,8 +8,8 @@ import hudson.model.Result;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.model.Actionable;
 import hudson.util.Graph;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.File;
 
@@ -90,7 +90,7 @@ public class CloverProjectAction extends Actionable implements ProminentProjectA
         return null;
     }
 
-    public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp) {
+    public DirectoryBrowserSupport doDynamic(StaplerRequest2 req, StaplerResponse2 rsp) {
 
         // there is a report if there was a build already, and there is a report
         if (project.getLastBuild() != null && getDisplayName() != null) {

--- a/src/main/java/hudson/plugins/clover/CloverPublisher.java
+++ b/src/main/java/hudson/plugins/clover/CloverPublisher.java
@@ -21,7 +21,7 @@ import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
@@ -354,7 +354,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
             req.bindParameters(this, "clover.");
             save();
             return super.configure(req, formData);
@@ -364,7 +364,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
          * Creates a new instance of {@link CloverPublisher} from a submitted form.
          */
         @Override
-        public CloverPublisher newInstance(@NonNull StaplerRequest req, @NonNull JSONObject formData) {
+        public CloverPublisher newInstance(@NonNull StaplerRequest2 req, @NonNull JSONObject formData) {
             final CloverPublisher instance = new CloverPublisher(
                     req.getParameter("clover.cloverReportDir"),
                     req.getParameter("clover.cloverReportFileName"),
@@ -385,7 +385,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
             return true;
         }
 
-        private CoverageTarget fromRequest(StaplerRequest req, String namePrefix) {
+        private CoverageTarget fromRequest(StaplerRequest2 req, String namePrefix) {
             return new CoverageTarget(
                     getIntParameter(req, namePrefix + "methodCoverage"),
                     getIntParameter(req, namePrefix + "conditionalCoverage"),
@@ -393,7 +393,7 @@ public class CloverPublisher extends Recorder implements SimpleBuildStep {
             );
         }
 
-        private Integer getIntParameter(StaplerRequest req, String name) {
+        private Integer getIntParameter(StaplerRequest2 req, String name) {
             try {
                 return Integer.valueOf(req.getParameter(name));
             } catch (NumberFormatException ex) {

--- a/src/main/java/hudson/plugins/clover/results/FileCoverage.java
+++ b/src/main/java/hudson/plugins/clover/results/FileCoverage.java
@@ -2,8 +2,8 @@ package hudson.plugins.clover.results;
 
 import hudson.model.Run;
 import hudson.plugins.clover.CloverBuildAction;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +19,7 @@ public class FileCoverage extends AbstractClassAggregatedMetrics {
         return getClassCoverages();
     }
 
-    public ClassCoverage getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public ClassCoverage getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         return findClassCoverage(token);
     }
 

--- a/src/main/java/hudson/plugins/clover/results/PackageCoverage.java
+++ b/src/main/java/hudson/plugins/clover/results/PackageCoverage.java
@@ -2,8 +2,8 @@ package hudson.plugins.clover.results;
 
 import hudson.model.Run;
 import hudson.plugins.clover.CloverBuildAction;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +42,7 @@ public class PackageCoverage extends AbstractFileAggregatedMetrics {
         return null;
     }
 
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         boolean isPath = false;
         for (FileCoverage i : fileCoverages) {
             if (i.getName().equals(token)) return i;
@@ -79,7 +79,7 @@ public class PackageCoverage extends AbstractFileAggregatedMetrics {
             this.pathSoFar = pathSoFar;
         }
 
-        public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+        public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
             final String testPath = pathSoFar + token;
             boolean isPath = false;
             for (FileCoverage i : fileCoverages) {

--- a/src/main/java/hudson/plugins/clover/results/ProjectCoverage.java
+++ b/src/main/java/hudson/plugins/clover/results/ProjectCoverage.java
@@ -2,8 +2,8 @@ package hudson.plugins.clover.results;
 
 import hudson.model.Run;
 import hudson.plugins.clover.CloverBuildAction;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +53,7 @@ public class ProjectCoverage extends AbstractPackageAggregatedMetrics {
         return null;
     }
 
-    public PackageCoverage getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public PackageCoverage getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         return findPackageCoverage(token);
     }
 


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`