### PR TITLE
OC-266: use inputs.pluginVersion instead of inputs.releaseVersion

### DIFF
--- a/.github/workflows/Bump-version.yml
+++ b/.github/workflows/Bump-version.yml
@@ -34,8 +34,8 @@ jobs:
           mvn --no-transfer-progress versions:set-property -Dproperty=revision "-DnewVersion=${{ inputs.pluginVersion }}" -DgenerateBackupPoms=false
           mvn --no-transfer-progress versions:set-property -Dproperty=clover.version "-DnewVersion=${{ inputs.opencloverVersion }}" -DgenerateBackupPoms=false
           git add .
-          git commit -m "Prepare release tag clover-${{ inputs.releaseVersion }}"
-          git tag clover-${{ inputs.releaseVersion }}
-          echo "Pushing commits and tag clover-${{ inputs.releaseVersion }}"
+          git commit -m "Prepare release tag clover-${{ inputs.pluginVersion }}"
+          git tag clover-${{ inputs.pluginVersion }}
+          echo "Pushing commits and tag clover-${{ inputs.pluginVersion }}"
           git push origin
-          git push origin clover-${{ inputs.releaseVersion }}
+          git push origin clover-${{ inputs.pluginVersion }}


### PR DESCRIPTION
Wrong variable was used to create a tag.

```
[master 9f6748c] Prepare release tag clover-
 1 file changed, 1 insertion(+), 1 deletion(-)
Pushing commits and tag clover-
To https://github.com/jenkinsci/clover-plugin
   5a7370f..9f6748c  master -> master
To https://github.com/jenkinsci/clover-plugin
 ! [rejected]        clover- -> clover- (already exists)
```

### Testing done

Will be tested by running the job.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira  - N/A
- [x] Link to relevant pull requests, esp. upstream and downstream changes - N/A
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
